### PR TITLE
Fixes runtime exception when running on Java 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play-json" % "2.3.5",
-    "net.databinder.dispatch" %% "dispatch-core" % "0.11.2",
+    "net.databinder.dispatch" %% "dispatch-core" % "0.11.3",
     "org.specs2" %% "specs2" % "2.3.13" % "test"
 )
 
@@ -20,7 +20,7 @@ libraryDependencies ++= Seq(
 moduleName := "maxpsq-gmapsclient"
 
 /* Sonatype repo credential for publishing (publish-signed) */
-credentials += Credentials(Path.userHome / ".sbt" / ".sonatype_credentials.sbt") 
+credentials += Credentials(Path.userHome / ".sbt" / ".sonatype_credentials.sbt")
 
 publishMavenStyle := true
 


### PR DESCRIPTION
This fixes a runtime exception when running on Play 2.4.x and java 8.

[RuntimeException: java.lang.NoSuchMethodError: com.ning.http.client.AsyncHttpClientConfig$Builder.setRequestTimeoutInMs(I)Lcom/ning/http/client/AsyncHttpClientConfig$Builder;]

Updated dispatch-core to 0.11.3 for 1.9.x version of Async Http Client which runs on Java 8.

