### PR TITLE
Rename parameter 'apikey' -> 'key'

### DIFF
--- a/src/main/scala/com/github/maxpsq/googlemaps/Parameters.scala
+++ b/src/main/scala/com/github/maxpsq/googlemaps/Parameters.scala
@@ -13,7 +13,7 @@ abstract class ClientParameter(key: String, value: Any) extends Parameter(key, v
 object GoogleParameters {
 
   // Google API Key  
-  case class ApiKeyParam (value: String) extends ClientParameter("apikey", value) {
+  case class ApiKeyParam (value: String) extends ClientParameter("key", value) {
     override def isValid: Boolean = true 
   }  
   


### PR DESCRIPTION
According to https://developers.google.com/maps/documentation/geocoding/intro#GeocodingRequests it should be 'key' instead of 'apikey'. I tested and it doesn't work with 'apikey'. Here is bugfix.