### PR TITLE
Use 'https' when calling Google API

### DIFF
--- a/src/main/scala/com/github/maxpsq/googlemaps/geocoding/Geocode.scala
+++ b/src/main/scala/com/github/maxpsq/googlemaps/geocoding/Geocode.scala
@@ -30,7 +30,7 @@ class GeocodeClient(http: Http, cpars: Seq[ClientParameter]) extends GoogleClien
  * Constant values to be injected into the client instance
  */
 object GeocodeClient {
-  val req = url("http://maps.googleapis.com") / "maps" / "api" / "geocode" / "json"
+  val req = url("https://maps.googleapis.com") / "maps" / "api" / "geocode" / "json"
 }
 
 


### PR DESCRIPTION
It is required when calling API with 'key' parameter. Without this fix I receive error "Requests to this API must be over SSL. Load the API with "https://" instead of "http://"